### PR TITLE
Enhance RPC field feedback

### DIFF
--- a/EntityViewDelegate.qml
+++ b/EntityViewDelegate.qml
@@ -86,7 +86,7 @@ Rectangle {
                 readOnly: true
                 text: {
                     if(isRPC) {
-                        return "Last Result: " + root.lastResult
+                        return root.rpcTrace === undefined ? "Result: " + root.lastResult : "Running..."
                     }
                     return valueToString(root.entity[componentName]);
                 }


### PR DESCRIPTION
* Display 'Running...' while RPC is pending. Not only that we get better
  feedback for long running RPCs, we see things change running RPC with same
  result multiple times
* Shorten 'Last Result' to 'Result'

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>